### PR TITLE
Add handling for command line arguments

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -1,45 +1,61 @@
 #include "Application.hpp"
+#include <ios>
 #include <vector>
 #include <iostream>
 #include <iomanip>
+#include <format>
 
 namespace Chess {
 
 void PrintHelp()
 {
-  // Usage: chess [options]
-  // Options:
-  //   --mode {window | console}    Sets the mode for opening chess
-  //   --help                       Display help
   std::cout << "Usage: chess [options]\n\n";
-  std::cout << "Options:\n";
+  std::cout << std::setw(26) << std::left
+            << "Options:"
+            << "\tDescription\n";
 
-  std::cout << std::setw(26) 
-            << "\t--mode {console | window}"
+  std::cout << std::setw(26) << std::left
+            << "  --mode {console | window}"
             << "\tSets the mode for opening chess\n";
 
-  std::cout << std::setw(26) 
-            << "\t--help"
+  std::cout << std::setw(26) << std::left
+            << "  --help"
             << "\tDisplay help\n";
 }
 
 ApplicationBase* EvalCMDArguments(int argc, char** argv)
 {
-  std::vector<std::string> arguments(argc);
+  std::vector<std::string> arguments;
   for (int i = 0; i < argc; i++) {
     arguments.push_back(argv[i]);
   }
+
   if (arguments.size() == 1) {
-    return new WindowApplication;
+    return nullptr;//new WindowApplication;
   }
-  else if (arguments.size() == 3) {
+  else if (arguments.size() >= 2) {
+    if (arguments[1] == "--help") {
+      PrintHelp();
+      return nullptr;
+    }
+    else if (arguments[1] != "--mode") {
+      std::cout << std::format("Unknown option: {}\n", arguments[1]);
+      PrintHelp();
+      return nullptr;
+    }
+    else if (arguments.size() == 2) {
+      std::cout << "You cannot use --mode without passing the correct mode\n";
+    }
+  }
+  if (arguments.size() >= 3) {
     if (arguments[2] == "window") {
-      return new WindowApplication;
+      return nullptr;//new WindowApplication;
     }
     else if (arguments[2] == "console") {
-      return new ConsoleApplication;
+      return nullptr;//new ConsoleApplication;
     }
     else {
+      std::cout << std::format("Unknown mode: {}\n", arguments[2]);
       PrintHelp();
       return nullptr;
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,7 +15,10 @@
 
 int main(int argc, char** argv) {
   auto game = Chess::EvalCMDArguments(argc, argv);
-  //game->Run();
+  if (game) {
+    game->Run();
+  }
   delete game;
+  return 0;
 }
 


### PR DESCRIPTION
Commented out "return new *Application" statements because Application classes aren't implemented yet.